### PR TITLE
Citrix CI: fix log upload failure

### DIFF
--- a/clouds.yaml
+++ b/clouds.yaml
@@ -1,0 +1,8 @@
+clouds:
+ mordred:
+   region_name: DFW
+   auth:
+     username: 'citrix.nodepool2'
+     password: 'Node88p00l'
+     project_name: XXXXXX
+     auth_url: 'https://identity.api.rackspacecloud.com/v2.0/'


### PR DESCRIPTION
After openstack sdk upgrade to 0.10.0, connection creates would fail because
of API change. Modify it.
Need copy cloud.yaml to /root/jenkins/.conf/openstack/
Need install os_client_config pkg