### PR TITLE
Citrix CI: fix logs upload failure

### DIFF
--- a/clouds.yaml
+++ b/clouds.yaml
@@ -1,0 +1,8 @@
+clouds:
+ rax:
+   region_name: DFW
+   auth:
+     username: 'citrix.nodepool2'
+     password: ''
+     project_name: '874240'
+     auth_url: 'https://identity.api.rackspacecloud.com/v2.0/'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pbr<1.0.0
+os-client-config
 python-openstacksdk


### PR DESCRIPTION
Because of openstack sdk upgrade, connection create would be failed
because of API changes. Used new API to fix this error.
Need install pkg os_client_config and set cloud.yaml.