### PR TITLE
Fix an AttributeError at uploading file

### DIFF
--- a/swiftuploader/upload.py
+++ b/swiftuploader/upload.py
@@ -160,7 +160,7 @@ class SwiftUploader(object):
                                                        content_encoding=content_encoding,
                                                        content_type=content_type)
 
-        if (obj == None):
+        if (obj is None):
             if attempt < 5:
                 self.logger.error('Upload of %s to %s failed - retrying'%(source, target))
                 self.upload_one_file(container, source, target, attempt+1)
@@ -206,7 +206,7 @@ class SwiftUploader(object):
             if cont.name == container_name:
                 container = cont
                 break
-        if container == None:
+        if container is None:
             # pylint: disable=no-member
             container = self.conn.object_store.create_container(name=container_name)
 


### PR DESCRIPTION
The OpenStack's resource class has overriden the "==" operator:
https://github.com/openstack/python-openstacksdk/blob/master/openstack/resource.py#L330

but it doesn't take account of the case that the comparing dest object is None.
If we run into the branch in upload.py to compare a resource object with
"None", it will fail with following error. This commit is to fix it
via using "<obj> is None" instead of "<obj> == None".

03:21:57 Traceback (most recent call last):
03:21:57   File "swift-uploader/swiftuploader/upload.py", line 253, in <module>
03:21:57     sys.exit(main())
03:21:57   File "swift-uploader/swiftuploader/upload.py", line 249, in main
03:21:57     uploader.upload(options.container, local_dirs, cf_prefix)
03:21:57   File "swift-uploader/swiftuploader/upload.py", line 209, in upload
03:21:57     if container == None:
03:21:57   File "/home/jenkins/.local/lib/python2.7/site-packages/openstack/resource.py", line 330, in __eq__
03:21:57     return all([self._body.attributes == comparand._body.attributes,
03:21:57 AttributeError: 'NoneType' object has no attribute '_body'