### PR TITLE
Fix the issue of "unexpected keyword argument 'constructor'"

### DIFF
--- a/swiftuploader/upload.py
+++ b/swiftuploader/upload.py
@@ -3,7 +3,6 @@
 import logging
 import optparse
 import os
-import os_client_config
 import sys
 import re
 import time
@@ -129,10 +128,7 @@ def set_cloud_password(password, cloud_name):
 
 def create_connection(password, cloud_name):
     set_cloud_password(password, cloud_name)
-    opts = cloud_conf(cloud_name)
-    occ = os_client_config.OpenStackConfig()
-    cloud = occ.get_one_cloud(opts.cloud)
-    conn = connection.from_config(cloud_config=cloud, options=opts)
+    conn = connection.from_config(cloud=cloud_name)
     set_cloud_password(PWD_COVER, cloud_name)
     conn.authorize()
     return conn


### PR DESCRIPTION
There is interface change in the new release of openstacksdk (bug/1755465)
which caused the following failure for os-client-config:
"TypeError: get_session_client() got an unexpected keyword argument 'constructor'.

Further more, it's recommending to use openstacksdk directly instead of
using os-client-config.

This commit is to use remove os-client-config but use openstacksdk
directly.